### PR TITLE
option to pass a type to enclosure

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -87,7 +87,7 @@ function generateXML (data){
                         _attr : {
                             url : item.enclosure.url,
                             length : item.enclosure.size || getSize(item.enclosure.file),
-                            type : mime.lookup(item.enclosure.file)
+                            type : item.enclosure.type || mime.lookup(item.enclosure.file)
                         }
                     }
                 });
@@ -97,7 +97,7 @@ function generateXML (data){
                         _attr : {
                             url : item.enclosure.url,
                             length : item.enclosure.size || 0,
-                            type : mime.lookup(item.enclosure.url)
+                            type : item.enclosure.type || mime.lookup(item.enclosure.url)
                         }
                     }
                 });

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,16 @@ feed.item(itemOptions);
  * `lat` _optional_ **number** The latitude coordinate of the item.
  * `long` _optional_ **number** The longitude coordinate of the item.
  * `custom_elements` _optional_ **array** Put additional elements in the item (node-xml syntax)
+ * `enclosure` _optional_ **object** An enclosure object
+    ```js
+    /* enclosure takes url or file key for the enclosure object */
+    {
+      'url'    : 'http://www.example.com/path/to/image', // url or path to binary, keys are url or file
+      'length' : 1668, // the size of the file // optional
+      'type'   : 'image/jpeg' // optional, if not provided the mimetype will be guessed based on the extension of the file or url, passing type to the enclosure will override the guessed type
+    }
 
+    ```
 ##### Feed XML
 
 ```js

--- a/readme.md
+++ b/readme.md
@@ -68,11 +68,20 @@ feed.item(itemOptions);
  * `custom_elements` _optional_ **array** Put additional elements in the item (node-xml syntax)
  * `enclosure` _optional_ **object** An enclosure object
     ```js
-    /* enclosure takes url or file key for the enclosure object */
+    /* enclosure takes url or file key for the enclosure object
+
+      url:  _required_ url to file object (or file)
+      file: _required_ path to binary file (or url)
+      size: _optional_ size of the file
+      type: _optional_ if not provided the mimetype will be guessed
+                       based on the extension of the file or url,
+                       passing type to the enclosure will override the guessed type
+    */
+
     {
-      'url'    : 'http://www.example.com/path/to/image', // url or path to binary, keys are url or file
-      'length' : 1668, // the size of the file // optional
-      'type'   : 'image/jpeg' // optional, if not provided the mimetype will be guessed based on the extension of the file or url, passing type to the enclosure will override the guessed type
+      'url'  : 'http://www.example.com/path/to/image',
+      'size' : 1668, //
+      'type' : 'image/jpeg'
     }
 
     ```

--- a/templates/readme/usage.md
+++ b/templates/readme/usage.md
@@ -55,7 +55,25 @@ feed.item(itemOptions);
  * `lat` _optional_ **number** The latitude coordinate of the item.
  * `long` _optional_ **number** The longitude coordinate of the item.
  * `custom_elements` _optional_ **array** Put additional elements in the item (node-xml syntax)
+ * `enclosure` _optional_ **object** An enclosure object
+    ```js
+    /* enclosure takes url or file key for the enclosure object
 
+      url:  _required_ url to file object (or file)
+      file: _required_ path to binary file (or url)
+      size: _optional_ size of the file
+      type: _optional_ if not provided the mimetype will be guessed
+                       based on the extension of the file or url,
+                       passing type to the enclosure will override the guessed type
+    */
+
+    {
+      'url'  : 'http://www.example.com/path/to/image',
+      'size' : 1668, //
+      'type' : 'image/jpeg'
+    }
+
+    ```
 #### Feed XML
 
 ```js

--- a/test/expectedOutput/enclosure_mimetype_override.xml
+++ b/test/expectedOutput/enclosure_mimetype_override.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+    <channel>
+        <title><![CDATA[title]]></title>
+        <description><![CDATA[description]]></description>
+        <link>http://example.com</link>
+        <generator>RSS for Node</generator>
+        <lastBuildDate>Wed, 10 Dec 2014 19:04:57 GMT</lastBuildDate>
+        <atom:link href="http://example.com/rss.xml" rel="self" type="application/rss+xml"/>
+        <author><![CDATA[Dylan Greene]]></author>
+        <item>
+            <title><![CDATA[item 1]]></title>
+            <description><![CDATA[description 1]]></description>
+            <link>http://example.com/article1</link>
+            <guid isPermaLink="true">http://example.com/article1</guid>
+            <dc:creator><![CDATA[Dylan Greene]]></dc:creator>
+            <pubDate>Thu, 24 May 2012 04:00:00 GMT</pubDate>
+            <enclosure url="/media/some-file-without-extension" length="0" type="custom-video/x-flv"/>
+        </item>
+        <item>
+            <title><![CDATA[item 2]]></title>
+            <description><![CDATA[description 2]]></description>
+            <link>http://example.com/article1</link>
+            <guid isPermaLink="true">http://example.com/article1</guid>
+            <dc:creator><![CDATA[Dylan Greene]]></dc:creator>
+            <pubDate>Thu, 24 May 2012 04:00:00 GMT</pubDate>
+            <enclosure url="/media/image.png" length="16650" type="image/jpeg"/>
+        </item>
+    </channel>
+</rss>

--- a/test/index.js
+++ b/test/index.js
@@ -137,6 +137,43 @@ test('enclosure', function(t) {
     t.equal(feed.xml({indent: true}), expectedOutput.enclosures);
 });
 
+test('enclosure_mimetype_override', function(t) {
+    //if (typeof window) return;
+
+    t.plan(1);
+
+    var feed = new RSS({
+        title: 'title',
+        description: 'description',
+        feed_url: 'http://example.com/rss.xml',
+        site_url: 'http://example.com',
+        author: 'Dylan Greene'
+    });
+
+
+    feed.item({
+        title:  'item 1',
+        description: 'description 1',
+        url: 'http://example.com/article1',
+        date: 'May 24, 2012 04:00:00 GMT',
+        enclosure : {url: '/media/some-file-without-extension', type: 'custom-video/x-flv'}
+    });
+
+    feed.item({
+        title:  'item 2',
+        description: 'description 2',
+        url: 'http://example.com/article1',
+        date: 'May 24, 2012 04:00:00 GMT',
+        enclosure : {
+            url: '/media/image.png',
+            file: __dirname + '/image.png',
+            size: 16650, // this is optional
+            type: 'image/jpeg' // we set this just to prove that the override works
+        }
+    });
+
+    t.equal(feed.xml({indent: true}), expectedOutput.enclosure_mimetype_override);
+});
 
 test('geoRSS', function(t) {
     t.plan(1);


### PR DESCRIPTION
mime.lookup() is not able to get the correct mimetype for urls that do not have a file extension.
this causes a problem with the feed validation.
by allowing a `type` value in the enclosure object this would override the mime lookup and use the passed in one.