### PR TITLE
Fix typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,5 +78,5 @@
       "folderify"
     ]
   },
-  "licenses": "MIT"
+  "license": "MIT"
 }


### PR DESCRIPTION
This tiny pull request changes `licenses` to `license` in `package.json`, to bring the file within [npm's guidelines](https://docs.npmjs.com/files/package.json#license).

This should make it that much easier for automated tools to confirm the MIT license.