### PR TITLE
Dont auto generate last build date

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,8 @@ function generateXML (data){
         channel.push({ image:  [ {url: data.image_url}, {title: data.title},  {link: data.site_url} ] });
     }
     channel.push({ generator:       data.generator });
-    channel.push({ lastBuildDate:   new Date().toUTCString() });
+    if (data.lastBuildDate)
+    	channel.push({ lastBuildDate:  data.lastBuildDate });
 
     ifTruePush(data.feed_url, channel, { 'atom:link': { _attr: { href: data.feed_url, rel: 'self', type: 'application/rss+xml' } } });
     ifTruePush(data.author, channel, { 'author': { _cdata: data.author } });


### PR DESCRIPTION
I'm not sure whether this is useful for others. In our case we were checking E-Tag header to figure out any feed change. Because this lastBuildDate is auto generated, the E-Tag was always changing though no feed item got changed.
