### PR TITLE
Move grunt-cli package.json to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,13 @@ matrix:
   include:
     - node_js: '0.10'
       before_install: npm -g i npm@2
+      before_script: npm -g i grunt-cli
     - node_js: '0.12'
       before_install: npm -g i npm@2
+      before_script: npm -g i grunt-cli
     - node_js: '4'
       before_install: npm -g i npm@2
+      before_script: npm -g i grunt-cli
     - node_js: '4'
       before_install: npm -g i npm@3
-
+      before_script: npm -g i grunt-cli

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     ]
   },
   "dependencies": {
-    "grunt-cli": "^0.1.13",
     "mime-types": "^2.1.7",
     "xml": "^1.0.0"
   },


### PR DESCRIPTION
Hi

When installed this library warning has raised

```
npm WARN prefer global grunt-cli@0.1.13 should be installed with -g
```

Thanks

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dylang/node-rss/55)
<!-- Reviewable:end -->
