### PR TITLE
exclude empty length/type values from enclosures

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,23 +81,39 @@ function generateXML (data){
         ifTruePush(item.long, item_values, {'geo:long': item.long});
 
         if( item.enclosure && item.enclosure.url) {
+            var length = item.enclosure.size || 0;
+            var type = item.enclosure.type || mime.lookup(item.enclosure.url);
             if( item.enclosure.file ) {
+                length = item.enclosure.size || getSize(item.enclosure.file);
+                type = item.enclosure.type || mime.lookup(item.enclosure.file);
+            }
+            if( length && type ) {
                 item_values.push({
                     enclosure : {
                         _attr : {
                             url : item.enclosure.url,
-                            length : item.enclosure.size || getSize(item.enclosure.file),
-                            type : item.enclosure.type || mime.lookup(item.enclosure.file)
+                            length : length,
+                            type : type
                         }
                     }
                 });
-            } else {
+            }
+            else if( length ) {
                 item_values.push({
                     enclosure : {
                         _attr : {
                             url : item.enclosure.url,
-                            length : item.enclosure.size || 0,
-                            type : item.enclosure.type || mime.lookup(item.enclosure.url)
+                            length : length
+                        }
+                    }
+                });
+            }
+            else if( type ) {
+                item_values.push({
+                    enclosure : {
+                        _attr : {
+                            url : item.enclosure.url,
+                            type : type
                         }
                     }
                 });


### PR DESCRIPTION
For #51. If you can't figure out the enclosure's size or type, just leave the attribute out and let the client figure it out. Though according to the [spec](http://www.rssboard.org/rss-specification#ltenclosuregtSubelementOfLtitemgt), these attributes are required.
