### PR TITLE
Allow user to specify type attr in atom:link

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,7 +41,7 @@ function generateXML (data){
     channel.push({ generator:       data.generator });
     channel.push({ lastBuildDate:   new Date().toUTCString() });
 
-    ifTruePush(data.feed_url, channel, { 'atom:link': { _attr: { href: data.feed_url, rel: 'self', type: 'application/rss+xml' } } });
+    ifTruePush(data.feed_url, channel, { 'atom:link': { _attr: { href: data.feed_url, rel: 'self', type: data.type } } });
     ifTruePush(data.author, channel, { 'author': { _cdata: data.author } });
     ifTruePush(data.pubDate, channel, { 'pubDate': new Date(data.pubDate).toGMTString() });
     ifTruePush(data.copyright, channel, { 'copyright':  { _cdata: data.copyright } });
@@ -143,6 +143,7 @@ function RSS (options, items) {
     this.generator          = options.generator || 'RSS for Node';
     this.feed_url           = options.feed_url;
     this.site_url           = options.site_url;
+    this.type               = options.type || 'application/rss+xml';
     this.image_url          = options.image_url;
     this.author             = options.author;
     this.categories         = options.categories;


### PR DESCRIPTION
Technically, 'application/rss+xml' isn't a valid media type (https://www.iana.org/assignments/media-types/media-types.xhtml).  This could cause problems in some browsers or RSS readers.  While leaving it as the default, allow users to specify a type in feedOptions.