### PR TITLE
I added the namespace xmlns:mi

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -115,6 +115,7 @@ function generateXML (data){
         'xmlns:dc':         'http://purl.org/dc/elements/1.1/',
         'xmlns:content':    'http://purl.org/rss/1.0/modules/content/',
         'xmlns:atom':       'http://www.w3.org/2005/Atom',
+        'xmlns:mi':         'http://schemas.ingestion.microsoft.com/common/',
         version: '2.0'
     };
 


### PR DESCRIPTION
As per MSN specification for the mRSS extension, it is required to have RSS elements such as:
<mi:hasSyndicationRights>1</mi:hasSyndicationRights>
<mi:licenseId>698525</mi:licenseId>
<mi:licensorName>Licensor name</mi:licensorName>
<mi:dateTimeWritten>2016-01-10T10:00:00+0100</mi:dateTimeWritten>.
So I extended the list of attributes of the namespace of this library to accept elements in form of "mi: "