### PR TITLE
Allow custom attributes for feed items

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -64,6 +64,7 @@ function generateXML (data){
         var item_values = [
                     { title:        { _cdata: item.title } }
                 ];
+        ifTruePush(item._attr, item_values, { _attr: item._attr });
         ifTruePush(item.description, item_values, { description:  { _cdata: item.description } });
         ifTruePush(item.url, item_values, { link: item.url });
         ifTruePush(item.link || item.guid || item.title, item_values, { guid:         [ { _attr: { isPermaLink: !item.guid && !!item.url } }, item.guid || item.url || item.title ]  });
@@ -163,6 +164,7 @@ function RSS (options, items) {
     this.item = function (options) {
         options = options || {};
         var item = {
+            _attr:            options._attr,
             title:            options.title || 'No title',
             description:      options.description || '',
             url:              options.url,


### PR DESCRIPTION
Required for [Yandex.Zen](https://yandex.ru/support/webmaster/turbo/feed.html) integration.