### PR TITLE
Remove underlying technology hints

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,9 +38,9 @@ function generateXML (data){
     if (data.image_url) {
         channel.push({ image:  [ {url: data.image_url}, {title: data.title},  {link: data.site_url} ] });
     }
-    channel.push({ generator:       data.generator });
     channel.push({ lastBuildDate:   new Date().toUTCString() });
 
+    ifTruePush(data.generator, { generator:       data.generator });
     ifTruePush(data.feed_url, channel, { 'atom:link': { _attr: { href: data.feed_url, rel: 'self', type: 'application/rss+xml' } } });
     ifTruePush(data.author, channel, { 'author': { _cdata: data.author } });
     ifTruePush(data.pubDate, channel, { 'pubDate': new Date(data.pubDate).toGMTString() });

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,7 @@ function generateXML (data){
     var channel = [];
     channel.push({ title:           { _cdata: data.title } });
     channel.push({ description:     { _cdata: data.description || data.title } });
-    channel.push({ link:            data.site_url || 'http://github.com/dylang/node-rss' });
+    channel.push({ link:            data.site_url });
     // image_url set?
     if (data.image_url) {
         channel.push({ image:  [ {url: data.image_url}, {title: data.title},  {link: data.site_url} ] });
@@ -140,7 +140,7 @@ function RSS (options, items) {
 
     this.title              = options.title || 'Untitled RSS Feed';
     this.description        = options.description || '';
-    this.generator          = options.generator || 'RSS for Node';
+    this.generator          = options.generator;
     this.feed_url           = options.feed_url;
     this.site_url           = options.site_url;
     this.image_url          = options.image_url;


### PR DESCRIPTION
Might be good to not force revealing the technology running the site. Maybe there is another way to link to the project? (or a way that can be secured via something like https://github.com/helmetjs/helmet )