### PR TITLE
add dateFormatter to RSS constructor options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,12 @@ function getSize(filename) {
     return fs.statSync(filename).size;
 }
 
-function generateXML (data){
+function defaultDateFormatter(date) {
+    return new Date(date).toUTCString()
+}
+
+function generateXML (data) {
+    const dateFormatter = data.dateFormatter
 
     var channel = [];
     channel.push({ title:           { _cdata: data.title } });
@@ -43,7 +48,7 @@ function generateXML (data){
 
     ifTruePush(data.feed_url, channel, { 'atom:link': { _attr: { href: data.feed_url, rel: 'self', type: 'application/rss+xml' } } });
     ifTruePush(data.author, channel, { 'author': { _cdata: data.author } });
-    ifTruePush(data.pubDate, channel, { 'pubDate': new Date(data.pubDate).toGMTString() });
+    ifTruePush(data.pubDate, channel, { 'pubDate': dateFormatter(data.pubDate) });
     ifTruePush(data.copyright, channel, { 'copyright':  { _cdata: data.copyright } });
     ifTruePush(data.language, channel, { 'language': { _cdata: data.language } });
     ifTruePush(data.managingEditor, channel, { 'managingEditor': { _cdata: data.managingEditor } });
@@ -73,7 +78,7 @@ function generateXML (data){
         });
 
         ifTruePush(item.author || data.author, item_values, { 'dc:creator': { _cdata: item.author || data.author } });
-        ifTruePush(item.date, item_values, { pubDate:      new Date(item.date).toGMTString() });
+        ifTruePush(item.date, item_values, { pubDate: dateFormatter(item.date) });
 
         //Set GeoRSS to true if lat and long are set
         data.geoRSS = data.geoRSS || (item.lat && item.long);
@@ -159,6 +164,7 @@ function RSS (options, items) {
     this.custom_namespaces  = options.custom_namespaces || {};
     this.custom_elements    = options.custom_elements || [];
     this.items              = items || [];
+    this.dateFormatter      = options.dateFormatter || defaultDateFormatter
 
     this.item = function (options) {
         options = options || {};

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,7 @@ var feed = new RSS(feedOptions);
  * `hub` _optional_ **PubSubHubbub hub url** Where is the PubSubHub hub located.
  * `custom_namespaces` _optional_ **object** Put additional namespaces in <rss> element (without 'xmlns:' prefix)
  * `custom_elements` _optional_ **array** Put additional elements in the feed (node-xml syntax)
+ * `dateFormatter` _optional_ **function** A function that receives the feed `pubDate` field and each item's `date` field. Allows for using a custom date format. Defaults to `new Date(date).toUTCString()`.
 
 #### Add items to a feed
 


### PR DESCRIPTION
Adds the ability to pass in a `dateFormatter` function to the `RSS` constructor, which will receive the raw date object for the feed `pubDate`, and each item's `date` fields. Enables using a custom date format.

This also changes the default date format function from `.toGMTString()` to `.toUTCString()`.

Fixes #90 