### PR TITLE
Option to disable CDATA for <title> and <description>

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,8 +31,8 @@ function getSize(filename) {
 function generateXML (data){
 
     var channel = [];
-    channel.push({ title:           { _cdata: data.title } });
-    channel.push({ description:     { _cdata: data.description || data.title } });
+    channel.push({ title: data.disable_cdata ? data.title: { _cdata: data.title }});
+    channel.push({ description: data.disable_cdata  ? data.description: { _cdata: data.description || data.title } });
     channel.push({ link:            data.site_url || 'http://github.com/dylang/node-rss' });
     // image_url set?
     if (data.image_url) {
@@ -140,6 +140,7 @@ function RSS (options, items) {
 
     this.title              = options.title || 'Untitled RSS Feed';
     this.description        = options.description || '';
+    this.disable_cdata      = options.disable_cdata || false;
     this.generator          = options.generator || 'RSS for Node';
     this.feed_url           = options.feed_url;
     this.site_url           = options.site_url;

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,7 @@ var feed = new RSS(feedOptions);
 
  * `title` **string** Title of your site or feed
  * `description` _optional_ **string** A short description of the feed.
+ * `disable_cdata` _optional_ **boolean** Disables CDATA for `title` and `description` if true.
  * `generator` _optional_  **string** Feed generator.
  * `feed_url` **url string** Url to the rss feed.
  * `site_url` **url string** Url to the site that the feed is for.


### PR DESCRIPTION
Some RSS feed subscription services (Inoreader, Stitcher.com), don't like it when there's `CDATA` in the `<title>` and `<description>` of the site, so I suggest adding a flag that allows you to disable those values

By default, if a user doesn't specify a value for the option `disable_cdata`, it becomes `false` which is just the current functionality of the `node-rss`