### PR TITLE
Added Attribute xmlns:media

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -115,6 +115,7 @@ function generateXML (data){
         'xmlns:dc':         'http://purl.org/dc/elements/1.1/',
         'xmlns:content':    'http://purl.org/rss/1.0/modules/content/',
         'xmlns:atom':       'http://www.w3.org/2005/Atom',
+        'xmlns:media':       'http://search.yahoo.com/mrss/',
         version: '2.0'
     };
 


### PR DESCRIPTION
Hi,

I was getting an error on multiple Gatsby Builds until I added this attribute to the existing list of attributes.

Error: 
error on multiple lines: Namespace prefix media on content is not defined

Fixed error by adding:
xmlns:media="http://search.yahoo.com/mrss/"

Thanks for a great package.